### PR TITLE
Make access token optional

### DIFF
--- a/src/create-report-request-fn.ts
+++ b/src/create-report-request-fn.ts
@@ -8,8 +8,8 @@ import { ReadableSpan } from '@opentelemetry/tracing';
  * Creates and returns a createReportRequest function
  *
  * @param runtimeGUID
- * @param accessToken
  * @param reporterTags
+ * @param accessToken
  */
 export function createReportRequestFn(
   runtimeGUID: string,

--- a/src/create-report-request-fn.ts
+++ b/src/create-report-request-fn.ts
@@ -13,8 +13,8 @@ import { ReadableSpan } from '@opentelemetry/tracing';
  */
 export function createReportRequestFn(
   runtimeGUID: string,
-  accessToken: string,
-  reporterTags: { [key: string]: any }
+  reporterTags: { [key: string]: any },
+  accessToken?: string
 ): (spans: ReadableSpan[]) => ls.ReportRequest {
   const auth: ls.Auth = new api.Auth({ accessToken });
   let reporter: ls.Reporter;

--- a/src/models/auth.ts
+++ b/src/models/auth.ts
@@ -1,8 +1,8 @@
 import * as ls from '../types';
 export class Auth implements ls.Auth {
-  readonly accessToken: string;
+  readonly accessToken?: string;
 
-  constructor({ accessToken }: { accessToken: string }) {
+  constructor({ accessToken }: { accessToken?: string }) {
     this.accessToken = accessToken;
   }
 }

--- a/src/platform/browser/send-spans-fn.ts
+++ b/src/platform/browser/send-spans-fn.ts
@@ -1,6 +1,6 @@
 /**
- * @param accessToken
  * @param urlToSend
+ * @param accessToken
  */
 export function sendSpansFn(
   urlToSend: string,

--- a/src/platform/browser/send-spans-fn.ts
+++ b/src/platform/browser/send-spans-fn.ts
@@ -3,8 +3,8 @@
  * @param urlToSend
  */
 export function sendSpansFn(
-  accessToken: string,
-  urlToSend: string
+  urlToSend: string,
+  accessToken?: string
 ): (
   body: string,
   onSuccess: () => void,
@@ -42,7 +42,8 @@ export function sendSpansFn(
     xhr.open('POST', urlToSend);
     xhr.setRequestHeader('Accept', 'application/json');
     xhr.setRequestHeader('Content-Type', 'application/json');
-    xhr.setRequestHeader('LightStep-Access-Token', accessToken);
+    if (accessToken)
+      xhr.setRequestHeader('LightStep-Access-Token', accessToken);
     xhr.onreadystatechange = () => {
       if (xhr.readyState === XMLHttpRequest.DONE) {
         if (xhr.status >= 200 && xhr.status <= 299) {

--- a/src/platform/node/send-spans-fn.ts
+++ b/src/platform/node/send-spans-fn.ts
@@ -7,8 +7,8 @@ import * as url from 'url';
 /**
  * Creates and returns a suitable sendSpans function for browser
  *
- * @param accessToken
  * @param urlToSend
+ * @param accessToken
  */
 export function sendSpansFn(
   urlToSend: string,
@@ -30,7 +30,7 @@ export function sendSpansFn(
     port: parsedUrl.port,
     path: parsedUrl.path,
     method: 'POST',
-    headers: headers,
+    headers,
   };
   const request = parsedUrl.protocol === 'http:' ? http.request : https.request;
 

--- a/src/platform/node/send-spans-fn.ts
+++ b/src/platform/node/send-spans-fn.ts
@@ -11,37 +11,37 @@ import * as url from 'url';
  * @param urlToSend
  */
 export function sendSpansFn(
-  accessToken: string,
-  urlToSend: string
+  urlToSend: string,
+  accessToken?: string
 ): (
   body: string,
   onSuccess: () => void,
   onError: (status?: number) => void
 ) => void {
-  const _parsedUrl = url.parse(urlToSend);
-  const _headers: { [key: string]: any } = {
+  const parsedUrl = url.parse(urlToSend);
+  const headers: { [key: string]: any } = {
     Accept: 'application/json',
     'Content-Type': 'application/json',
-    'LightStep-Access-Token': accessToken,
   };
-  const _options = {
-    hostname: _parsedUrl.hostname,
-    port: _parsedUrl.port,
-    path: _parsedUrl.path,
+  if (accessToken) headers['LightStep-Access-Token'] = accessToken;
+
+  const options = {
+    hostname: parsedUrl.hostname,
+    port: parsedUrl.port,
+    path: parsedUrl.path,
     method: 'POST',
-    headers: _headers,
+    headers: headers,
   };
-  const request =
-    _parsedUrl.protocol === 'http:' ? http.request : https.request;
+  const request = parsedUrl.protocol === 'http:' ? http.request : https.request;
 
   return function(
     body: string,
     onSuccess: () => void,
     onError: (status?: number) => void
   ) {
-    _headers['Content-Length'] = Buffer.byteLength(body);
+    headers['Content-Length'] = Buffer.byteLength(body);
 
-    const req = request(_options, (res: IncomingMessage) => {
+    const req = request(options, (res: IncomingMessage) => {
       if (res.statusCode && res.statusCode < 299) {
         onSuccess();
       } else {

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,7 @@
  * An interface representing Auth.
  */
 export interface Auth {
-  readonly accessToken: string;
+  readonly accessToken?: string;
 }
 
 /**

--- a/test/browser/exporter.test.ts
+++ b/test/browser/exporter.test.ts
@@ -17,7 +17,7 @@ describe('LightstepExporter - web', () => {
     ExporterConfig = {
       serviceName: 'bar',
       token: 'abc',
-      collector_host: 'http://foo.bar.com',
+      collectorUrl: 'http://foo.bar.com',
     };
     exporter = new LightstepExporter(ExporterConfig);
     spans = [];

--- a/test/common/create-report-request.test.ts
+++ b/test/common/create-report-request.test.ts
@@ -10,8 +10,8 @@ describe('createReportRequest', () => {
     const tags = { foo: 'bar' };
     const result: ls.ReportRequest = createReportRequestFn(
       guid,
-      token,
-      tags
+      tags,
+      token
     )([spanWithParent]);
 
     assert.deepEqual(result, reportJSON, 'wrong report');

--- a/test/common/exporter.test.ts
+++ b/test/common/exporter.test.ts
@@ -2,30 +2,15 @@ import * as assert from 'assert';
 import { LightstepExporter } from '../../src';
 
 describe('LightstepExporter', () => {
-  it('should construct exporter', () => {
+  it('should construct exporter with token', () => {
     const exporter = new LightstepExporter({
       token: '123',
     });
     assert.ok(exporter instanceof LightstepExporter);
   });
-  it('should throw error for missing config', () => {
-    let error;
-    try {
-      // @ts-ignore
-      new LightstepExporter();
-    } catch (e) {
-      error = e;
-    }
-    assert.strictEqual(error, 'Missing config');
-  });
-  it('should throw error for missing token exporter', () => {
-    let error;
-    try {
-      // @ts-ignore
-      new LightstepExporter({});
-    } catch (e) {
-      error = e;
-    }
-    assert.strictEqual(error, 'Missing token');
+
+  it('should provide default config', () => {
+    const exporter = new LightstepExporter();
+    assert.ok(exporter instanceof LightstepExporter);
   });
 });

--- a/test/node/exporter.test.ts
+++ b/test/node/exporter.test.ts
@@ -25,7 +25,7 @@ describe('LightstepExporter - node', () => {
       exporterConfig = {
         token: 'abc',
         serviceName: 'bar',
-        collector_host: 'http://foo.bar.com',
+        collectorUrl: 'http://foo.bar.com',
       };
       exporter = new LightstepExporter(exporterConfig);
       spans = [];


### PR DESCRIPTION
The PR makes access token optional in order to support dev and single project mode. It also switches from using `collector_host`, `collector_port` etc to using `collectorUrl`. It's forgiving and will fill in defaults for missing data.

cc: @obecny